### PR TITLE
Rename `UByte.of` to `UByte.apply` so that we can call `UByte(0)`

### DIFF
--- a/src/main/scala/com/gonzaloquero/scal8/Cpu.scala
+++ b/src/main/scala/com/gonzaloquero/scal8/Cpu.scala
@@ -7,7 +7,7 @@ class Cpu(memory: Memory, graphicMemory: GraphicMemory, keyDispatcher: KeyDispat
   var programCounter: Short   = 0x200
   var stack: List[Short]      = List()
   val registers: Array[UByte] = new Array[UByte](16)
-  var delayTimer: UByte       = UByte.of(0)
+  var delayTimer: UByte       = UByte(0)
 
   def tick(): Unit = {
     val opCode = getNextOpCode
@@ -15,8 +15,8 @@ class Cpu(memory: Memory, graphicMemory: GraphicMemory, keyDispatcher: KeyDispat
   }
 
   def clockTick(): Unit = {
-    if (delayTimer > UByte.of(0)) {
-      delayTimer = delayTimer - UByte.of(1)
+    if (delayTimer > UByte(0)) {
+      delayTimer = delayTimer - UByte(1)
     }
   }
 
@@ -32,7 +32,7 @@ class Cpu(memory: Memory, graphicMemory: GraphicMemory, keyDispatcher: KeyDispat
   private def getOpCodeAddressValue(opCode: Short)          = (opCode & 0x0FFF).toShort
   private def getOpCodeXRegisterNumber(opCode: Short): Byte = ((opCode & 0x0F00) >>> 8).toByte
   private def getOpCodeYRegisterNumber(opCode: Short): Byte = ((opCode & 0x00F0) >>> 4).toByte
-  private def getOpCodeValue(opCode: Short): UByte          = UByte.of(opCode & 0x00FF)
+  private def getOpCodeValue(opCode: Short): UByte          = UByte(opCode & 0x00FF)
 
   private def executeOpCode(opCode: Short): Unit = opCode & 0xF000 match {
     case 0x0000 => opCode0XXX(opCode)
@@ -147,37 +147,37 @@ class Cpu(memory: Memory, graphicMemory: GraphicMemory, keyDispatcher: KeyDispat
 
         // TODO: This feels terrible. There has to be a better way.
         if ((0x00FF & registerXValue.getValue) + (0x0FF & registerYValue.getValue) > 0xFF) {
-          registers(0xF) = UByte.of(1)
+          registers(0xF) = UByte(1)
         } else {
-          registers(0xF) = UByte.of(0)
+          registers(0xF) = UByte(0)
         }
 
         result
       // 8XY5: VY is subtracted from VX. VF is set to 0 when there's a borrow, and 1 when there isn't.
       case 0x0005 =>
         registers(0xF) = if (registerXValue > registerYValue) {
-          UByte.of(1)
+          UByte(1)
         } else {
-          UByte.of(0)
+          UByte(0)
         }
 
         registerXValue - registerYValue
       // 8XY6: Stores the least significant bit of VX in VF and then shifts VX to the right by 1.
       case 0x0006 =>
-        registers(0xF) = registerXValue & UByte.of(0x0001)
+        registers(0xF) = registerXValue & UByte(0x0001)
         registerXValue >>> 1
       // 8XY7: Sets VX to VY minus VX. VF is set to 0 when there's a borrow, and 1 when there isn't.
       case 0x0007 =>
         registers(0xF) = if (registerYValue > registerXValue) {
-          UByte.of(1)
+          UByte(1)
         } else {
-          UByte.of(0)
+          UByte(0)
         }
 
         registerYValue - registerXValue
       // 8XYE: Stores the most significant bit of VX in VF and then shifts VX to the left by 1.
       case 0x000E =>
-        registers(0xF) = (registerXValue & UByte.of(0x80)) >>> 7
+        registers(0xF) = (registerXValue & UByte(0x80)) >>> 7
         registerXValue << 1
     }
   }
@@ -209,7 +209,7 @@ class Cpu(memory: Memory, graphicMemory: GraphicMemory, keyDispatcher: KeyDispat
     val registerXNumber = getOpCodeXRegisterNumber(opCode)
     val value           = getOpCodeValue(opCode)
 
-    registers(registerXNumber) = UByte.of(Random.nextInt(256) & value.getValue)
+    registers(registerXNumber) = UByte(Random.nextInt(256) & value.getValue)
   }
 
   // DXYN: Draws a sprite at coordinate (VX, VY) that has a width of 8 pixels and a height of N pixels.
@@ -220,7 +220,7 @@ class Cpu(memory: Memory, graphicMemory: GraphicMemory, keyDispatcher: KeyDispat
     val x               = Math.max(0, registers(registerXNumber).getValue)
     val y               = Math.max(0, registers(registerYNumber).getValue)
 
-    registers(0xF) = UByte.of(0)
+    registers(0xF) = UByte(0)
 
     var offsetY = 0
     for (dy <- y until (y + height)) {
@@ -235,7 +235,7 @@ class Cpu(memory: Memory, graphicMemory: GraphicMemory, keyDispatcher: KeyDispat
         val currentValue = graphicMemory.get(wrappedX, wrappedY)
         val bit          = if ((((newValue << dx) & 0x80) >>> 7) == 0) false else true
 
-        registers(0xF) = if (currentValue && !bit) { UByte.of(1) } else { registers(0xF) }
+        registers(0xF) = if (currentValue && !bit) { UByte(1) } else { registers(0xF) }
         graphicMemory.set(wrappedX, wrappedY, currentValue ^ bit)
       }
     }

--- a/src/main/scala/com/gonzaloquero/scal8/Main.scala
+++ b/src/main/scala/com/gonzaloquero/scal8/Main.scala
@@ -89,7 +89,7 @@ object Main extends JFXApp {
       Stream
         .continually(bis.read)
         .takeWhile(b => b != -1)
-        .map(UByte.of)
+        .map(UByte.apply)
     )
   }
 }

--- a/src/main/scala/com/gonzaloquero/scal8/UByte.scala
+++ b/src/main/scala/com/gonzaloquero/scal8/UByte.scala
@@ -18,19 +18,19 @@ class UByte private (value: Byte = 0) extends Ordered[UByte] {
 
   override def toString: String = f"0x$value%02x"
 
-  def -(that: UByte): UByte = UByte.of(value - that.getValue)
-  def +(that: UByte): UByte = UByte.of(value + that.getValue)
-  def |(that: UByte): UByte = UByte.of(value | that.getValue)
-  def &(that: UByte): UByte = UByte.of(value & that.getValue)
-  def ^(that: UByte): UByte = UByte.of(value ^ that.getValue)
-  def <<(bits: Int): UByte  = UByte.of(value << bits)
+  def -(that: UByte): UByte = UByte(value - that.getValue)
+  def +(that: UByte): UByte = UByte(value + that.getValue)
+  def |(that: UByte): UByte = UByte(value | that.getValue)
+  def &(that: UByte): UByte = UByte(value & that.getValue)
+  def ^(that: UByte): UByte = UByte(value ^ that.getValue)
+  def <<(bits: Int): UByte  = UByte(value << bits)
 
   // This sounds stupid, but we need to remove the MSB after every step because otherwise everything becomes Ints
   // with a lot of leading 1s
   def >>>(bits: Int): UByte = {
-    var res = UByte.of(value)
+    var res = UByte(value)
     for (_ <- 0 until bits) {
-      res = UByte.of((res.getValue >>> 1) & 0x7F)
+      res = UByte((res.getValue >>> 1) & 0x7F)
     }
 
     res
@@ -39,10 +39,10 @@ class UByte private (value: Byte = 0) extends Ordered[UByte] {
 }
 
 object UByte {
-  def of(b: Byte): UByte = new UByte(b)
-  def of(b: Int): UByte  = new UByte(b.toByte)
+  def apply(b: Byte): UByte = new UByte(b)
+  def apply(b: Int): UByte  = new UByte(b.toByte)
 }
 
 object UByteImplicits {
-  implicit def Int2UByte(value: Int): UByte = UByte.of(value)
+  implicit def Int2UByte(value: Int): UByte = UByte(value)
 }

--- a/src/test/scala/com/gonzaloquero/scal8/MemorySpec.scala
+++ b/src/test/scala/com/gonzaloquero/scal8/MemorySpec.scala
@@ -8,7 +8,7 @@ class MemorySpec extends FlatSpec with Matchers {
     val memory = Memory.withProgram(Array[UByte]())
 
     for (i <- 0 until 0xFFF) {
-      memory.get(i) should be(UByte.of(0))
+      memory.get(i) should be(UByte(0))
     }
   }
 
@@ -22,23 +22,23 @@ class MemorySpec extends FlatSpec with Matchers {
       ))
 
     for (i <- 0 until 0x200) {
-      memory.get(i) should be(UByte.of(0))
+      memory.get(i) should be(UByte(0))
     }
 
-    memory.get(0x200) should be(UByte.of(0x00))
-    memory.get(0x201) should be(UByte.of(0xE0))
-    memory.get(0x202) should be(UByte.of(0xA2))
-    memory.get(0x203) should be(UByte.of(0x48))
+    memory.get(0x200) should be(UByte(0x00))
+    memory.get(0x201) should be(UByte(0xE0))
+    memory.get(0x202) should be(UByte(0xA2))
+    memory.get(0x203) should be(UByte(0x48))
   }
 
   "get" should "return the value in the correspondent memory address" in {
     val memory = Memory.withProgram(Array[UByte](0x48))
-    memory.get(0x200) should be(UByte.of(0x48))
+    memory.get(0x200) should be(UByte(0x48))
   }
 
   "set" should "change the value of the memory address" in {
     val memory = Memory.withProgram(Array[UByte]())
     memory.set(0x200, 0x48)
-    memory.get(0x200) should be(UByte.of(0x48))
+    memory.get(0x200) should be(UByte(0x48))
   }
 }

--- a/src/test/scala/com/gonzaloquero/scal8/UByteSpec.scala
+++ b/src/test/scala/com/gonzaloquero/scal8/UByteSpec.scala
@@ -5,142 +5,142 @@ import org.scalatest._
 
 class UByteSpec extends FlatSpec with Matchers {
   "getValue" should "return the value of the UByte" in {
-    val a: UByte = UByte.of(1)
+    val a: UByte = UByte(1)
     a.getValue should be(1)
   }
 
   "equals" should "return true for two UBytes of the same value" in {
-    UByte.of(1).equals(UByte.of(1)) should be(true)
+    UByte(1).equals(UByte(1)) should be(true)
   }
 
   "==" should "return true for two UBytes of the same value" in {
-    UByte.of(1) == UByte.of(1) should be(true)
+    UByte(1) == UByte(1) should be(true)
   }
 
   "compare" should "return 0 if both are equal" in {
-    val a: UByte = UByte.of(1)
-    val b: UByte = UByte.of(1)
+    val a: UByte = UByte(1)
+    val b: UByte = UByte(1)
 
     a.compare(b) should be(0)
   }
 
   "compare" should "return -1 if the first value is lesser" in {
-    val a: UByte = UByte.of(1)
-    val b: UByte = UByte.of(2)
+    val a: UByte = UByte(1)
+    val b: UByte = UByte(2)
 
     a.compare(b) should be(-1)
   }
 
   "compare" should "return -1 between a value that would be over the sign and a lesser value" in {
-    val a: UByte = UByte.of(1)
-    val b: UByte = UByte.of(0xFF) // Could be 255 or -128
+    val a: UByte = UByte(1)
+    val b: UByte = UByte(0xFF) // Could be 255 or -128
 
     a.compare(b) should be(-1)
   }
 
   "compare" should "return 1 if the first value is higher" in {
-    val a: UByte = UByte.of(2)
-    val b: UByte = UByte.of(1)
+    val a: UByte = UByte(2)
+    val b: UByte = UByte(1)
 
     a.compare(b) should be(1)
   }
 
   "compare" should "return 1 between a value that would be over the sign and a lesser value" in {
-    val a: UByte = UByte.of(0xFF) // Could be 255 or -128
-    val b: UByte = UByte.of(1)
+    val a: UByte = UByte(0xFF) // Could be 255 or -128
+    val b: UByte = UByte(1)
 
     a.compare(b) should be(1)
   }
 
   "compare" should "return 1 between a value that would be over the sign and a lesser value (2)" in {
-    val a: UByte = UByte.of(0xFF) // Could be 255 or -128
-    val b: UByte = UByte.of(0xFE)
+    val a: UByte = UByte(0xFF) // Could be 255 or -128
+    val b: UByte = UByte(0xFE)
 
     a.compare(b) should be(1)
   }
 
   "-" should "calculate a - b" in {
-    val a: UByte = UByte.of(3)
-    val b: UByte = UByte.of(2)
+    val a: UByte = UByte(3)
+    val b: UByte = UByte(2)
 
-    (a - b) should be(UByte.of(1))
+    (a - b) should be(UByte(1))
   }
 
   "-" should "calculate a - b for values over the sign change" in {
-    val a: UByte = UByte.of(0xFF)
-    val b: UByte = UByte.of(1)
+    val a: UByte = UByte(0xFF)
+    val b: UByte = UByte(1)
 
-    (a - b) should be(UByte.of(0xFE))
+    (a - b) should be(UByte(0xFE))
   }
 
   "+" should "calculate a + b" in {
-    val a: UByte = UByte.of(3)
-    val b: UByte = UByte.of(2)
+    val a: UByte = UByte(3)
+    val b: UByte = UByte(2)
 
-    (a + b) should be(UByte.of(5))
+    (a + b) should be(UByte(5))
   }
 
   "+" should "overflow a + b" in {
-    val a: UByte = UByte.of(0xFF)
-    val b: UByte = UByte.of(1)
+    val a: UByte = UByte(0xFF)
+    val b: UByte = UByte(1)
 
-    (a + b) should be(UByte.of(0))
+    (a + b) should be(UByte(0))
   }
 
   "|" should "calculate a | b" in {
-    val a: UByte = UByte.of(4)
-    val b: UByte = UByte.of(2)
+    val a: UByte = UByte(4)
+    val b: UByte = UByte(2)
 
-    (a | b) should be(UByte.of(6))
+    (a | b) should be(UByte(6))
   }
 
   "&" should "calculate a & b" in {
-    val a: UByte = UByte.of(7)
-    val b: UByte = UByte.of(6)
+    val a: UByte = UByte(7)
+    val b: UByte = UByte(6)
 
-    (a & b) should be(UByte.of(6))
+    (a & b) should be(UByte(6))
   }
 
   "^" should "calculate a xor b" in {
-    val a: UByte = UByte.of(7)
-    val b: UByte = UByte.of(6)
+    val a: UByte = UByte(7)
+    val b: UByte = UByte(6)
 
-    (a ^ b) should be(UByte.of(1))
+    (a ^ b) should be(UByte(1))
   }
 
   ">>>" should "shift a >>> x" in {
-    val a: UByte = UByte.of(2)
+    val a: UByte = UByte(2)
 
-    (a >>> 1) should be(UByte.of(1)) // 1 bit shift is equivalent to dividing by 2
+    (a >>> 1) should be(UByte(1)) // 1 bit shift is equivalent to dividing by 2
   }
 
   ">>>" should "shift a >>> x (2)" in {
-    val a: UByte = UByte.of(4)
+    val a: UByte = UByte(4)
 
-    (a >>> 2) should be(UByte.of(1)) // 1 bit shift is equivalent to dividing by 2
+    (a >>> 2) should be(UByte(1)) // 1 bit shift is equivalent to dividing by 2
   }
 
   ">>>" should "shift a >>> x (3)" in {
-    val a: UByte = UByte.of(0xFF)
+    val a: UByte = UByte(0xFF)
 
-    (a >>> 1) should be(UByte.of(0x7F)) // 1 bit shift is equivalent to dividing by 2
+    (a >>> 1) should be(UByte(0x7F)) // 1 bit shift is equivalent to dividing by 2
   }
 
   ">>>" should "shift a >>> x (4)" in {
-    val a: UByte = UByte.of(0xFF)
+    val a: UByte = UByte(0xFF)
 
-    (a >>> 2) should be(UByte.of(0x3F)) // 1 bit shift is equivalent to dividing by 2
+    (a >>> 2) should be(UByte(0x3F)) // 1 bit shift is equivalent to dividing by 2
   }
 
   "<<" should "shift a << x" in {
-    val a: UByte = UByte.of(2)
+    val a: UByte = UByte(2)
 
-    (a << 1) should be(UByte.of(4)) // 1 bit shift is equivalent to multiplying by 2
+    (a << 1) should be(UByte(4)) // 1 bit shift is equivalent to multiplying by 2
   }
 
   "implicits" should "convert an int to a UByte" in {
     val a: UByte = 1
 
-    a should be(UByte.of(1))
+    a should be(UByte(1))
   }
 }


### PR DESCRIPTION
Turns out that adding an `apply` function to a companion object allows you to call `Object(X)` on it without specifying the method. This fits very well the nature of `UByte.of` as a constructor and makes it slightly shorter and more readable.